### PR TITLE
updated year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jens Steube,
-Copyright (c) 2015 magnum
+Copyright (c) 2015-2016 Jens Steube,
+Copyright (c) 2015-2016 magnum
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Since it is already 2016, I would like to suggest that we update the LICENCE/Copyright file for this project to say "2015-2016".
This is a small fix that is just cosmetic (for the MIT license).
Thx