### PR TITLE
Makefile cleanup: remove comments about hashcat-toolchain

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,6 @@
 CFLAGS = -W -Wall -std=c99 -O2 -s
 #CFLAGS = -W -Wall -std=c99 -g
 
-#CC_LINUX32        = /opt/hashcat-toolchain/linux32/bin/i686-hashcat-linux-gnu-gcc
-#CC_LINUX64        = /opt/hashcat-toolchain/linux64/bin/x86_64-hashcat-linux-gnu-gcc
 CC_LINUX32        = gcc
 CC_LINUX64        = gcc
 CC_WINDOWS32      = /usr/bin/i686-w64-mingw32-gcc


### PR DESCRIPTION
I would like to suggest that we remove comments about hashcat-toolchain in the Makefile since we didn't used it for quite some time. Back then, it was used to compile the linux binaries to make them compatible with older glibc versions.
Since we do not need this anymore we should really removed these (confusing) comments with those hard-coded paths etc.
Thx