### PR TITLE
Optionally use a "floating" max. elements count.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+# This repo is f@cked up with CRLF so this config will ensure your
+# editor keeps using the same format.
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/src/pp.c
+++ b/src/pp.c
@@ -19,7 +19,9 @@
  * Name........: princeprocessor (pp)
  * Description.: Standalone password candidate generator using the PRINCE algorithm
  * Version.....: 0.22
- * Autor.......: Jens Steube <jens.steube@gmail.com>
+ * Authors.....: Jens Steube <jens.steube@gmail.com>
+ *               Steve Thomas (Sc00bz)
+ *               magnum <john.magnum@hushmail.com>
  * License.....: MIT
  */
 
@@ -823,9 +825,9 @@ int main (int argc, char *argv[])
     return (-1);
   }
 
-  if (elem_cnt_max <= 0)
+  if (elem_cnt_max < (1 - pw_max))
   {
-    fprintf (stderr, "Value of --elem-cnt-max (%d) must be greater than %d\n", elem_cnt_max, 0);
+    fprintf (stderr, "Value of --elem-cnt-max (%d) must be greater than %d\n", elem_cnt_max, (0 - pw_max));
 
     return (-1);
   }
@@ -837,7 +839,7 @@ int main (int argc, char *argv[])
     return (-1);
   }
 
-  if (elem_cnt_min > elem_cnt_max)
+  if (elem_cnt_max > 0 && elem_cnt_min > elem_cnt_max)
   {
     fprintf (stderr, "Value of --elem-cnt-min (%d) must be smaller or equal than value of --elem-cnt-max (%d)\n", elem_cnt_min, elem_cnt_max);
 
@@ -1078,7 +1080,20 @@ int main (int argc, char *argv[])
 
       if (valid2 == 0) continue;
 
-      int valid3 = chain_valid_with_cnt_max (&chain_buf_new, elem_cnt_max);
+      int eff_elem_cnt_max;
+
+      if (elem_cnt_max > 0)
+      {
+        eff_elem_cnt_max = elem_cnt_max;
+      }
+      else
+      {
+        eff_elem_cnt_max = pw_len + elem_cnt_max;
+
+        if (eff_elem_cnt_max <= elem_cnt_min) continue;
+      }
+
+      int valid3 = chain_valid_with_cnt_max (&chain_buf_new, eff_elem_cnt_max);
 
       if (valid3 == 0) continue;
 


### PR DESCRIPTION
I found this quite useful for some runs. The change is well out of inner loops.

Example. Using a wordlist like this:

```
alpha
bravo
charlie
delta
(...)
!
#
%
&
/
```

Running this, you probably want things like `alpha#delta` or `!charlie/bravo` while you don't really want words consisting solely of one-char elements, like `!#%!%#!#` (I think they do come in the very end, but I didn't want them at all). With this patch you can use --elem-cnt-max=-1 which will mean "current pw_len - 1" for all lengths. So you will always have one of the longer words included even if running to end.
