### PR TITLE
cosmetic: 'oclHashcat' -> 'hashcat', 'hashcat' -> 'hashcat-legacy'

### DIFF
--- a/rules/prince_generated.rule
+++ b/rules/prince_generated.rule
@@ -1,6 +1,6 @@
 ## Name: prince.rule
 ## Version: 1.00
-## Compatibility: hashcat v0.48+, oclHashcat v1.31+
+## Compatibility: hashcat-legacy v0.48+, hashcat v2.00+
 ##
 ## Description: 
 ##

--- a/rules/prince_optimized.rule
+++ b/rules/prince_optimized.rule
@@ -1,6 +1,6 @@
 ## Name: prince.rule
 ## Version: 1.00
-## Compatibility: hashcat v0.48+, oclHashcat v1.31+
+## Compatibility: hashcat-legacy v0.48+, hashcat v2.00+
 ##
 ## Description: 
 ##


### PR DESCRIPTION
We should try to get rid of all instances of the name "oclHashcat" and replace it with just "hashcat" (because of the project renaming).
Accordingly, we need to replace "hashcat" with "hashcat-legacy".

This is of course a cosmetic fix only, but it tries to avoid confusion about which tool/project is meant.

Thanks