### PR TITLE
minor: license year should be 2018 by now

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Jens Steube,
-Copyright (c) 2015-2016 magnum
+Copyright (c) 2015-2018 Jens Steube,
+Copyright (c) 2015-2018 magnum
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
this just makes sure that the LICENSE file is up to date and reflects the current year we are living in: 2018!

Happy new year

Thank you very much