### PR TITLE
Removed header from Makefile so princeprocessor compiles on Mac OS X

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ clean:
 pp32.bin: pp.c mpz_int128.h
 	$(CC_LINUX32)   $(CFLAGS_LINUX32)   -o $@ $^
 
-pp64.bin: pp.c mpz_int128.h
+pp64.bin: pp.c
 	$(CC_LINUX64)   $(CFLAGS_LINUX64)   -o $@ $^
 
 pp32.exe: pp.c mpz_int128.h


### PR DESCRIPTION
Removed header file from Makefile so princeprocessor compiles on Mac OS X.

This was the advised method on [Stackoverflow](https://stackoverflow.com/questions/43525486/cannot-specify-o-when-generating-multiple-output-files-c-error).